### PR TITLE
Initial version with Spring Boot 1.3.X and below

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.iml
+.idea/
 target/
 pom.xml.tag
 pom.xml.releaseBackup

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,34 @@
+= Spring Boot ShrinkWrap Archive
+
+This specific ShrinkWrap archive allows you to create Spring Boot archives.
+The basic archive is class is `org.shrinkwrap.springboot.api.SpringBoot13Archive`.
+
+== SpringBootArchive for Spring Boot versions prior to 1.4.X
+
+To create a Spring Boot archive you need to use `org.shrinkwrap.springboot.api.SpringBoot13Archive` in `ShrinkWrap.create` method.
+
+[source, java]
+----
+ShrinkWrap.create(SpringBoot13Archive.class)
+        .addClass(org.shrinkwrap.springboot.app.HelloController.class) // <1>
+
+        .addLibs(Maven.resolver()
+                   .resolve("org.springframework.boot:spring-boot-starter-web:1.3.5.RELEASE")
+                   .withTransitivity()
+                   .as(JavaArchive.class)
+        ) // <2>
+
+       .addLauncher(Maven.resolver()
+                    .resolve("org.springframework.boot:spring-boot-loader:1.3.5.RELEASE")
+                    .withTransitivity()
+                    .as(JavaArchive.class)
+       ) // <3>
+
+       .addSpringBootApplication(Application.class); // <4>
+----
+<1> Normal call of ShrinkWrap method.
+<2> Libraries must be bundled inside `/lib` directory. `addLibs` adds libraries in correct place.
+<3> Spring Boot application needs a launcher to run the application.
+<4> Class that contains the `main` method.
+
+IMPORTANT: To materialize a Spring Boot application you need to use `ZipStoredExporter`, for example `springBoot13Archive.as(ZipStoredExporter.class).exportTo(new File("/tmp/app.jar"));`

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.shrinkwrap</groupId>
+        <artifactId>shrinkwrap-springboot-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>shrinkwrap-spring-boot-api</artifactId>
+    <name>ShrinkWrap Spring Boot :: API</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/api/src/main/java/org/shrinkwrap/springboot/api/SpringBoot13Archive.java
+++ b/api/src/main/java/org/shrinkwrap/springboot/api/SpringBoot13Archive.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.shrinkwrap.springboot.api;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+
+/**
+ * Implements Launching executable JARS for Spring Boot versions prior to 1.4.X apps,
+ * following http://docs.spring.io/spring-boot/docs/1.3.5.RELEASE/reference/htmlsingle/#executable-jar strategy
+ *
+ * Basically the most important thing to remain is that libs are placed in a root directory called lib.
+ *
+ * @author <a href="asotobu@gmail.com">Alex Soto</a>
+ */
+public interface SpringBoot13Archive extends Archive<SpringBoot13Archive>, ServiceProviderContainer<SpringBoot13Archive>  {
+
+    /**
+     * This method adds the Spring Boot application class (one with main method) inside current archive.
+     * @param startClass application class
+     * @return Spring Boot Archive with application class added
+     */
+    SpringBoot13Archive addSpringBootApplication(Class<?> startClass);
+
+    /**
+     * This method adds a library inside current Spring Boot archive. In terms of Spring Boot format it adds this library into lib directory using STORED method.
+     * @param lib to add
+     * @return Spring Boot Archive with given library added
+     */
+    SpringBoot13Archive addLib(JavaArchive lib);
+
+    /**
+     * This method adds all libraries as Spring Boot library
+     * @param libs to add
+     * @return Spring Boot Archive with given libraries added
+     */
+    SpringBoot13Archive addLibs(JavaArchive...libs);
+
+    /**
+     * This method adds the Java Archive that contains the Spring Boot loader
+     * @param launcher java archive containing Spring Boot loader
+     * @return Spring Boot Archive with Spring Boot loader added
+     */
+    SpringBoot13Archive addLauncher(JavaArchive... launcher);
+
+}

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.shrinkwrap</groupId>
+        <artifactId>shrinkwrap-springboot-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>shrinkwrap-spring-boot-ftest</artifactId>
+    <name>ShrinkWrap Spring Boot :: FTEST</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-spring-boot-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/ftest/src/main/java/org/shrinkwrap/springboot/app/Application.java
+++ b/ftest/src/main/java/org/shrinkwrap/springboot/app/Application.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.shrinkwrap.springboot.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        ApplicationContext ctx = SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/ftest/src/main/java/org/shrinkwrap/springboot/app/HelloController.java
+++ b/ftest/src/main/java/org/shrinkwrap/springboot/app/HelloController.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.shrinkwrap.springboot.app;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @RequestMapping("/")
+    public String index() {
+        return "Greetings From Spring Boot";
+    }
+
+}

--- a/ftest/src/test/java/org/shrinkwrap/springboot/app/SpringBoot13Test.java
+++ b/ftest/src/test/java/org/shrinkwrap/springboot/app/SpringBoot13Test.java
@@ -24,6 +24,7 @@ import org.shrinkwrap.springboot.api.SpringBoot13Archive;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.Callable;
@@ -73,12 +74,16 @@ public class SpringBoot13Test {
             final Callable<Integer> statusCode = new Callable<Integer>() {
                 @Override
                 public Integer call() throws Exception {
-                    URL url = new URL("http://localhost:8080");
-                    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-                    connection.setRequestMethod("GET");
-                    connection.connect();
+                    try {
+                        URL url = new URL("http://localhost:8080");
+                        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                        connection.setRequestMethod("GET");
+                        connection.connect();
 
-                    return connection.getResponseCode();
+                        return connection.getResponseCode();
+                    } catch(ConnectException e) {
+                        return 404;
+                    }
                 }
             };
 

--- a/ftest/src/test/java/org/shrinkwrap/springboot/app/SpringBoot13Test.java
+++ b/ftest/src/test/java/org/shrinkwrap/springboot/app/SpringBoot13Test.java
@@ -12,7 +12,6 @@
 
 package org.shrinkwrap.springboot.app;
 
-import io.restassured.RestAssured;
 import org.awaitility.Duration;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipStoredExporter;

--- a/ftest/src/test/java/org/shrinkwrap/springboot/app/SpringBoot13Test.java
+++ b/ftest/src/test/java/org/shrinkwrap/springboot/app/SpringBoot13Test.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.shrinkwrap.springboot.app;
+
+import io.restassured.RestAssured;
+import org.awaitility.Duration;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipStoredExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.shrinkwrap.springboot.api.SpringBoot13Archive;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.Callable;
+
+import static io.restassured.RestAssured.get;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+/**
+ *
+ * Functional test that checks that the Spring Boot file created is bootable.
+ *
+ * @author <a href="asotobu@gmail.com">Alex Soto</a>
+ *
+ */
+public class SpringBoot13Test {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void should_create_valid_spring_boot_archive() throws IOException {
+
+
+        SpringBoot13Archive springBoot13Archive = ShrinkWrap.create(SpringBoot13Archive.class)
+                .addClass(HelloController.class)
+
+                .addLibs(Maven.resolver()
+                        .resolve("org.springframework.boot:spring-boot-starter-web:1.3.5.RELEASE")
+                        .withTransitivity()
+                        .as(JavaArchive.class)
+                )
+
+                .addLauncher(Maven.resolver()
+                        .resolve("org.springframework.boot:spring-boot-loader:1.3.5.RELEASE")
+                        .withTransitivity()
+                        .as(JavaArchive.class))
+
+                .addSpringBootApplication(Application.class);
+
+        springBoot13Archive.as(ZipStoredExporter.class).exportTo(new File(temporaryFolder.getRoot(), "app.jar"));
+        Process process = null;
+
+        try {
+            process = new ProcessBuilder("java", "-jar", temporaryFolder.getRoot().getAbsolutePath() + "/app.jar").start();
+
+            final Callable<Integer> statusCode = new Callable<Integer>() {
+                @Override
+                public Integer call() throws Exception {
+                    URL url = new URL("http://localhost:8080");
+                    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                    connection.setRequestMethod("GET");
+                    connection.connect();
+
+                    return connection.getResponseCode();
+                }
+            };
+
+            await()
+                    .atMost(Duration.TEN_SECONDS)
+                    .until(statusCode, equalTo(200));
+
+            get().then().body(equalTo("Greetings From Spring Boot"));
+        } finally {
+            if (process != null) {
+                process.destroy();
+            }
+        }
+    }
+
+}

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <parent>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-springboot-parent</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
+   </parent>
+   <artifactId>shrinkwrap-spring-boot-impl</artifactId>
+   <name>ShrinkWrap Spring Boot :: IMPL</name>
+
+   <dependencies>
+
+      <dependency>
+         <groupId>org.jboss.shrinkwrap</groupId>
+         <artifactId>shrinkwrap-spring-boot-api</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.shrinkwrap</groupId>
+         <artifactId>shrinkwrap-api</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.shrinkwrap</groupId>
+         <artifactId>shrinkwrap-impl-base</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.assertj</groupId>
+         <artifactId>assertj-core</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.shrinkwrap.resolver</groupId>
+         <artifactId>shrinkwrap-resolver-depchain</artifactId>
+         <type>pom</type>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter-web</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+   </dependencies>
+
+</project>

--- a/impl/src/main/java/org/shrinkwrap/springboot/impl/SpringBoot13ArchiveImpl.java
+++ b/impl/src/main/java/org/shrinkwrap/springboot/impl/SpringBoot13ArchiveImpl.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.shrinkwrap.springboot.impl;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipStoredExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.impl.base.container.ContainerBase;
+import org.jboss.shrinkwrap.impl.base.path.BasicPath;
+import org.shrinkwrap.springboot.api.SpringBoot13Archive;
+
+/**
+ * Implementation of the {@link SpringBoot13Archive} interface
+ *
+ * @author <a href="asotobu@gmail.com">Alex Soto</a>
+ */
+public class SpringBoot13ArchiveImpl extends ContainerBase<SpringBoot13Archive> implements SpringBoot13Archive {
+
+    public SpringBoot13ArchiveImpl(Archive<?> archive) {
+        super(SpringBoot13Archive.class, archive);
+    }
+
+    /**
+     * Path to the manifests inside of the Archive.
+     */
+    private static final ArchivePath PATH_MANIFEST = new BasicPath("META-INF");
+
+    /**
+     * Path to the resources inside of the Archive.
+     */
+    private static final ArchivePath PATH_RESOURCE = new BasicPath("/");
+
+    /**
+     * Path to the classes inside of the Archive.
+     */
+    private static final ArchivePath PATH_CLASSES = new BasicPath("/");
+
+    /**
+     * Path to the libraries inside of the Archive.
+     */
+    private static final ArchivePath PATH_LIBRARY = ArchivePaths.create(PATH_CLASSES, "lib");
+
+    private static final String MANIFEST_FILE = "" +
+            "Main-Class: org.springframework.boot.loader.JarLauncher" + System.lineSeparator() +
+            "Start-Class: %s" + System.lineSeparator();
+
+    @Override
+    public SpringBoot13Archive addSpringBootApplication(Class<?> startClass) {
+        this.addClass(startClass);
+        final StringAsset manifestContent = new StringAsset(String.format(MANIFEST_FILE, startClass.getName()));
+
+        this.addAsManifestResource(manifestContent, "MANIFEST.MF");
+        return this;
+    }
+
+    @Override
+    public SpringBoot13Archive addLib(JavaArchive lib) {
+        this.addAsDirectory(PATH_LIBRARY);
+        this.add(lib, PATH_LIBRARY, ZipStoredExporter.class);
+        return this;
+    }
+
+    @Override
+    public SpringBoot13Archive addLibs(JavaArchive... libs) {
+        for (JavaArchive lib : libs) {
+            this.addLib(lib);
+        }
+        return this;
+    }
+
+    @Override
+    public SpringBoot13Archive addLauncher(JavaArchive... launcher) {
+        for (JavaArchive l : launcher) {
+            this.merge(l);
+        }
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.declarchive.impl.base.ContainerBase#getManifestPath()
+     */
+    @Override
+    protected ArchivePath getManifestPath() {
+        return PATH_MANIFEST;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.impl.base.container.ContainerBase#getClassesPath()
+     */
+    @Override
+    protected ArchivePath getClassesPath() {
+        return PATH_CLASSES;
+    }
+
+    @Override
+    protected ArchivePath getLibraryPath() {
+        return PATH_LIBRARY;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.declarchive.impl.base.ContainerBase#getResourcePath()
+     */
+    @Override
+    protected ArchivePath getResourcePath() {
+        return PATH_RESOURCE;
+    }
+}

--- a/impl/src/main/java/org/shrinkwrap/springboot/impl/SpringBoot13ArchiveImpl.java
+++ b/impl/src/main/java/org/shrinkwrap/springboot/impl/SpringBoot13ArchiveImpl.java
@@ -95,7 +95,7 @@ public class SpringBoot13ArchiveImpl extends ContainerBase<SpringBoot13Archive> 
     /*
      * (non-Javadoc)
      *
-     * @see org.jboss.declarchive.impl.base.ContainerBase#getManifestPath()
+     * @see org.jboss.shrinkwrap.impl.base.container.ContainerBase#getClassesPath()
      */
     @Override
     protected ArchivePath getManifestPath() {
@@ -120,7 +120,7 @@ public class SpringBoot13ArchiveImpl extends ContainerBase<SpringBoot13Archive> 
     /*
      * (non-Javadoc)
      *
-     * @see org.jboss.declarchive.impl.base.ContainerBase#getResourcePath()
+     * @see org.jboss.shrinkwrap.impl.base.container.ContainerBase#getClassesPath()
      */
     @Override
     protected ArchivePath getResourcePath() {

--- a/impl/src/main/resources/META-INF/services/org.shrinkwrap.springboot.api.SpringBoot13Archive
+++ b/impl/src/main/resources/META-INF/services/org.shrinkwrap.springboot.api.SpringBoot13Archive
@@ -1,0 +1,2 @@
+implementingClassName=org.shrinkwrap.springboot.impl.SpringBoot13ArchiveImpl
+extension=.jar

--- a/impl/src/test/java/org/shrinkwrap/springboot/impl/SpringBoot13ArchiveImplTest.java
+++ b/impl/src/test/java/org/shrinkwrap/springboot/impl/SpringBoot13ArchiveImplTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.shrinkwrap.springboot.impl;
+
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.impl.base.path.BasicPath;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.shrinkwrap.springboot.api.SpringBoot13Archive;
+import org.springboot.Application;
+import org.springboot.HelloController;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for {@link SpringBoot13ArchiveImpl}
+ *
+ * @author <a href="asotobu@gmail.com">Alex Soto</a>
+ */
+public class SpringBoot13ArchiveImplTest {
+
+    private static SpringBoot13Archive springBoot13Archive;
+
+    @BeforeClass
+    public static void prepareSpringBootFile() {
+        springBoot13Archive = ShrinkWrap.create(SpringBoot13Archive.class)
+                .addClass(HelloController.class)
+
+                .addLibs(Maven.resolver()
+                            .resolve("org.springframework.boot:spring-boot-starter-web:1.3.5.RELEASE")
+                            .withTransitivity()
+                            .as(JavaArchive.class)
+                )
+
+                .addLauncher(Maven.resolver()
+                            .resolve("org.springframework.boot:spring-boot-loader:1.3.5.RELEASE")
+                            .withTransitivity()
+                            .as(JavaArchive.class))
+
+                .addSpringBootApplication(Application.class);
+    }
+
+    @Test
+    public void should_add_libs_in_lib_directory() {
+        final Node libDirectory = springBoot13Archive.get("/lib");
+        assertThat(libDirectory.getChildren())
+                .extracting("path")
+                .contains(new BasicPath("/lib/spring-boot-starter-web-1.3.5.RELEASE.jar"));
+    }
+
+    @Test
+    public void should_add_manifest_entries() {
+        final Asset manifest = springBoot13Archive.get("/META-INF/MANIFEST.MF").getAsset();
+        final InputStream inputStream = manifest.openStream();
+        assertThat(asString(inputStream))
+                .isEqualTo("Main-Class: org.springframework.boot.loader.JarLauncher\n" +
+                           "Start-Class: " + Application.class.getName() + "\n");
+    }
+
+    @Test
+    public void should_add_launcher() {
+        final Node jarLauncher = springBoot13Archive.get("/org/springframework/boot/loader/JarLauncher.class");
+        assertThat(jarLauncher).isNotNull();
+    }
+
+    private String asString(InputStream inputStream) {
+        String text = null;
+        try (Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8.name())) {
+            text = scanner.useDelimiter("\\A").next();
+        }
+
+        return text;
+    }
+
+}

--- a/impl/src/test/java/org/springboot/Application.java
+++ b/impl/src/test/java/org/springboot/Application.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        ApplicationContext ctx = SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/impl/src/test/java/org/springboot/HelloController.java
+++ b/impl/src/test/java/org/springboot/HelloController.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.springboot;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @RequestMapping("/")
+    public String index() {
+        return "Greetings From Spring Boot";
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>16</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.shrinkwrap</groupId>
+    <artifactId>shrinkwrap-springboot-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>ShrinkWrap Spring Boot :: Parent</name>
+
+    <properties>
+        <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <version.junit>4.12</version.junit>
+        <version.shrinkwrap-resolver-depchain>2.2.2</version.shrinkwrap-resolver-depchain>
+        <version.spring-boot-starter-web>1.4.1.RELEASE</version.spring-boot-starter-web>
+        <version.assertj-core>2.5.0</version.assertj-core>
+        <version.awaitility>2.0.0</version.awaitility>
+        <version.rest-assured>3.0.1</version.rest-assured>
+    </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>asotobu</id>
+            <name>Alex Soto</name>
+            <email>asotobu@gmail.com</email>
+        </developer>
+    </developers>
+
+    <modules>
+        <module>api</module>
+        <module>impl</module>
+        <module>ftest</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-spring-boot-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-spring-boot-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-api</artifactId>
+                <version>${version.org.jboss.shrinkwrap}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-impl-base</artifactId>
+                <version>${version.org.jboss.shrinkwrap}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${version.spring-boot-starter-web}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${version.awaitility}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>rest-assured</artifactId>
+                <version>${version.rest-assured}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-depchain</artifactId>
+                <version>${version.shrinkwrap-resolver-depchain}</version>
+                <scope>test</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj-core}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <scm>
+        <connection>scm:git:git://github.com/shrinkwrap/shrinkwrap-springboot.git</connection>
+        <developerConnection>scm:git:git@github.com:shrinkwrap/shrinkwrap-springboot.git</developerConnection>
+        <url>http://github.com/shrinkwrap/shrinkwrap-springboot</url>
+        <tag>HEAD</tag>
+    </scm>
+
+</project>


### PR DESCRIPTION
Initial commit for adding support for creating Spring Boot runnable jars in ShrinkWrap. Currently only Spring Boot 1.3.X or prior are supported.